### PR TITLE
Update Attention OCR README.me to point to a fixed checkpoint file.

### DIFF
--- a/attention_ocr/README.md
+++ b/attention_ocr/README.md
@@ -71,7 +71,7 @@ python train.py --checkpoint_inception=inception_v3.ckpt
 To fine tune the Attention OCR model using a checkpoint:
 
 ```
-wget http://download.tensorflow.org/models/attention_ocr_2017_05_17.tar.gz
+wget http://download.tensorflow.org/models/attention_ocr_2017_05_17.fixed.tar.gz
 tar xf attention_ocr_2017_05_17.tar.gz
 python train.py --checkpoint=model.ckpt-399731
 ```
@@ -160,16 +160,31 @@ as the example.
 The inference part was not released yet, but it is pretty straightforward to
 implement one in Python or C++.
 
-The recommended way is to use the [Serving infrastructure](https://tensorflow.github.io/serving/serving_basic).
+The recommended way is to use the [Serving infrastructure][serving].
 
 Alternatively you can:
 1. define a placeholder for images (or use directly an numpy array)
 2. [create a graph ](https://github.com/tensorflow/models/blob/master/attention_ocr/python/eval.py#L60)
-`endpoints = model.create_base(images_placeholder, labels_one_hot=None)`
+```
+endpoints = model.create_base(images_placeholder, labels_one_hot=None)
+```
 3. [load a pretrained model](https://github.com/tensorflow/models/blob/master/attention_ocr/python/model.py#L494)
 4. run computations through the graph:
-`predictions = sess.run(endpoints.predicted_chars, feed_dict={images_placeholder:images_actual_data})`
+```
+predictions = sess.run(endpoints.predicted_chars, 
+                       feed_dict={images_placeholder:images_actual_data})
+```
 5. Convert character IDs (predictions) to UTF8 using the provided charset file.
+
+Please note that tensor names may change overtime and old stored checkpoints can
+become unloadable. In many cases such backward incompatible changes can be
+fixed with a [string substitution][1] to update the checkpoint itself or using a
+custom var_list with [assign_from_checkpoint_fn][2]. For anything
+other than a one time experiment please use the [TensorFlow Serving][serving].
+
+[1]: https://github.com/tensorflow/tensorflow/blob/aaf7adc/tensorflow/contrib/rnn/python/tools/checkpoint_convert.py
+[2]: https://www.tensorflow.org/api_docs/python/tf/contrib/framework/assign_from_checkpoint_fn
+[serving]: https://tensorflow.github.io/serving/serving_basic
 
 ## Disclaimer
 


### PR DESCRIPTION
The existing checkpoint for the model
http://download.tensorflow.org/models/attention_ocr_2017_05_17.tar.gz
is now broken because of tensor name changes in the attention decoder. 
I applied the fix and sent request to @martinwicke to upload it.